### PR TITLE
Add minimal FastAPI and React auth example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,8 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+# Node
+node_modules/
+
+# Env
+.env

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,11 @@
+# FastAPI Backend
+
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+Run the development server:
+```bash
+uvicorn main:app --reload
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,88 @@
+from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm, OAuth2PasswordBearer
+from pydantic import BaseModel
+from passlib.context import CryptContext
+from jose import JWTError, jwt
+from datetime import datetime, timedelta
+from typing import Dict, Optional
+
+SECRET_KEY = "change-me"  # replace with a secure key in production
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+app = FastAPI()
+
+# In-memory user storage
+fake_users_db: Dict[str, Dict[str, str]] = {}
+
+class User(BaseModel):
+    username: str
+    disabled: Optional[bool] = False
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+
+class UserInDB(User):
+    hashed_password: str
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+def authenticate_user(username: str, password: str) -> Optional[UserInDB]:
+    user = fake_users_db.get(username)
+    if not user or not verify_password(password, user["hashed_password"]):
+        return None
+    return UserInDB(**user)
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+async def get_current_user(token: str = Depends(oauth2_scheme)) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = fake_users_db.get(username)
+    if user is None:
+        raise credentials_exception
+    return User(**user)
+
+@app.post("/signup")
+async def signup(user: UserCreate):
+    if user.username in fake_users_db:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    hashed_password = get_password_hash(user.password)
+    fake_users_db[user.username] = {"username": user.username, "hashed_password": hashed_password}
+    return {"msg": "User created"}
+
+@app.post("/token")
+async def login(form_data: OAuth2PasswordRequestForm = Depends()):
+    user = authenticate_user(form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    access_token = create_access_token(data={"sub": user.username},
+                                      expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    return {"access_token": access_token, "token_type": "bearer"}
+
+@app.get("/me")
+async def read_users_me(current_user: User = Depends(get_current_user)):
+    return current_user

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+python-jose
+passlib[bcrypt]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,13 @@
+# React Frontend
+
+This is a minimal React + TypeScript project with Tailwind CSS.
+
+Install dependencies (requires Node.js and npm):
+```bash
+npm install
+```
+
+Run the development server:
+```bash
+npm run dev
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Auth Example</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.9.0",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.0.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import Signup from "./Signup";
+import Login from "./Login";
+
+export default function App() {
+  return (
+    <div className="p-4">
+      <Signup />
+      <hr className="my-4" />
+      <Login />
+    </div>
+  );
+}

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from "react";
+import { login } from "./api";
+
+export default function Login() {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [token, setToken] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const data = await login(username, password);
+      setToken(data.access_token);
+    } catch {
+      alert("Failed to login");
+    }
+  };
+
+  return (
+    <div className="max-w-sm mx-auto">
+      <h1 className="text-xl font-bold mb-4">Login</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input className="border p-2 w-full" placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <input className="border p-2 w-full" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+        <button className="bg-blue-500 text-white py-2 px-4 rounded">Login</button>
+      </form>
+      {token && <p className="mt-4 break-all">Token: {token}</p>}
+    </div>
+  );
+}

--- a/frontend/src/Signup.tsx
+++ b/frontend/src/Signup.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from "react";
+import { signup } from "./api";
+
+export default function Signup() {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await signup(username, password);
+      setMessage("User created, please login.");
+    } catch {
+      alert("Failed to sign up");
+    }
+  };
+
+  return (
+    <div className="max-w-sm mx-auto">
+      <h1 className="text-xl font-bold mb-4">Signup</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input className="border p-2 w-full" placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <input className="border p-2 w-full" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+        <button className="bg-blue-500 text-white py-2 px-4 rounded">Signup</button>
+      </form>
+      {message && <p className="mt-4">{message}</p>}
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,28 @@
+const API_URL = "http://localhost:8000";
+
+export async function signup(username: string, password: string) {
+  const res = await fetch(`${API_URL}/signup`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}
+
+export async function login(username: string, password: string) {
+  const data = new URLSearchParams();
+  data.append("username", username);
+  data.append("password", password);
+  const res = await fetch(`${API_URL}/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: data.toString(),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client"]
+  }
+}


### PR DESCRIPTION
## Summary
- create `backend` with FastAPI app demonstrating signup and token login using JWT
- add `frontend` with React + TypeScript and Tailwind that implements signup & login forms
- update `.gitignore` for node and env files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fd9ec1ae08333ab1dd1474b13a432