### PR TITLE
Add basic dashboard and wallet features

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.0"
   },
   "devDependencies": {
     "typescript": "^4.9.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,31 @@
 import React from "react";
+import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import Signup from "./Signup";
 import Login from "./Login";
+import Dashboard from "./Dashboard";
+import UserPage from "./UserPage";
+import Wallet from "./Wallet";
+import Shop from "./Shop";
 
 export default function App() {
   return (
-    <div className="p-4">
-      <Signup />
-      <hr className="my-4" />
-      <Login />
-    </div>
+    <BrowserRouter>
+      <nav className="p-4 space-x-2 bg-gray-100">
+        <Link to="/">Auth</Link>
+        <Link to="/dashboard">Dashboard</Link>
+        <Link to="/user">User</Link>
+        <Link to="/wallet">Wallet</Link>
+        <Link to="/shop">Shop</Link>
+      </nav>
+      <div className="p-4">
+        <Routes>
+          <Route path="/" element={<><Signup /><hr className="my-4" /><Login /></>} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/user" element={<UserPage />} />
+          <Route path="/wallet" element={<Wallet />} />
+          <Route path="/shop" element={<Shop />} />
+        </Routes>
+      </div>
+    </BrowserRouter>
   );
 }

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from "react";
+import { getDashboard } from "./api";
+
+export default function Dashboard() {
+  const [services, setServices] = useState<{name: string; id: string; password: string;}[]>([]);
+
+  useEffect(() => {
+    getDashboard().then(data => setServices(data.services)).catch(() => {});
+  }, []);
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Active Services</h1>
+      <ul className="space-y-2">
+        {services.map(s => (
+          <li key={s.name} className="border p-2">
+            <div>{s.name}</div>
+            <div>ID: {s.id}</div>
+            <div>Password: {s.password}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -4,13 +4,14 @@ import { login } from "./api";
 export default function Login() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [token, setToken] = useState("");
+  const [token, setToken] = useState(localStorage.getItem("token") || "");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
       const data = await login(username, password);
       setToken(data.access_token);
+      localStorage.setItem("token", data.access_token);
     } catch {
       alert("Failed to login");
     }

--- a/frontend/src/Shop.tsx
+++ b/frontend/src/Shop.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export default function Shop() {
+  const services = [
+    { name: "Quillbot" },
+    { name: "Grammarly" }
+  ];
+  return (
+    <div className="max-w-sm mx-auto">
+      <h1 className="text-xl font-bold mb-4">Shop</h1>
+      <ul className="space-y-2">
+        {services.map(s => (
+          <li key={s.name} className="border p-2">{s.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/UserPage.tsx
+++ b/frontend/src/UserPage.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from "react";
+import { changePassword } from "./api";
+
+export default function UserPage() {
+  const [oldPassword, setOld] = useState("");
+  const [newPassword, setNew] = useState("");
+  const [msg, setMsg] = useState("");
+
+  const handle = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await changePassword(oldPassword, newPassword);
+      setMsg("Password updated");
+    } catch {
+      alert("Failed to change password");
+    }
+  };
+
+  return (
+    <div className="max-w-sm mx-auto">
+      <h1 className="text-xl font-bold mb-4">User</h1>
+      <form onSubmit={handle} className="space-y-2">
+        <input className="border p-2 w-full" type="password" placeholder="Old password" value={oldPassword} onChange={e => setOld(e.target.value)} />
+        <input className="border p-2 w-full" type="password" placeholder="New password" value={newPassword} onChange={e => setNew(e.target.value)} />
+        <button className="bg-blue-500 text-white py-2 px-4 rounded">Change Password</button>
+      </form>
+      {msg && <p className="mt-4">{msg}</p>}
+    </div>
+  );
+}

--- a/frontend/src/Wallet.tsx
+++ b/frontend/src/Wallet.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from "react";
+import { getWallet, deposit } from "./api";
+
+export default function Wallet() {
+  const [credits, setCredits] = useState(0);
+  const [amount, setAmount] = useState("");
+  const [address, setAddress] = useState("");
+
+  useEffect(() => {
+    getWallet().then(w => {
+      setCredits(w.credits);
+      setAddress(w.btc_address);
+    }).catch(() => {});
+  }, []);
+
+  const handle = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const data = await deposit(Number(amount));
+      setCredits(data.credits);
+      setAmount("");
+    } catch {
+      alert("Failed to deposit");
+    }
+  };
+
+  return (
+    <div className="max-w-sm mx-auto">
+      <h1 className="text-xl font-bold mb-4">Wallet</h1>
+      <p className="mb-2">Credits: {credits}</p>
+      <p className="mb-4">Bitcoin address: {address}</p>
+      <form onSubmit={handle} className="space-y-2">
+        <input className="border p-2 w-full" placeholder="Amount" value={amount} onChange={e => setAmount(e.target.value)} />
+        <button className="bg-blue-500 text-white py-2 px-4 rounded">Deposit</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,10 @@
 const API_URL = "http://localhost:8000";
 
+function authHeaders() {
+  const token = localStorage.getItem("token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 export async function signup(username: string, password: string) {
   const res = await fetch(`${API_URL}/signup`, {
     method: "POST",
@@ -24,5 +29,39 @@ export async function login(username: string, password: string) {
   if (!res.ok) {
     throw new Error(await res.text());
   }
+  return res.json();
+}
+
+export async function getDashboard() {
+  const res = await fetch(`${API_URL}/dashboard`, {
+    headers: { ...authHeaders() }
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function changePassword(oldPass: string, newPass: string) {
+  const res = await fetch(`${API_URL}/change-password`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ old_password: oldPass, new_password: newPass })
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function getWallet() {
+  const res = await fetch(`${API_URL}/wallet`, { headers: { ...authHeaders() } });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function deposit(amount: number) {
+  const res = await fetch(`${API_URL}/wallet/deposit`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ amount })
+  });
+  if (!res.ok) throw new Error(await res.text());
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add credit rate and user service storage
- create signup with default services
- implement dashboard, wallet, change-password API endpoints
- add React Router and new pages (dashboard, user, wallet, shop)
- support storing auth token in localStorage

## Testing
- `python3 -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6851102fb57c8333b25abad1983d0092