### PR TITLE
Add contact and subscriptions pages

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -141,3 +141,10 @@ async def wallet_deposit(dep: Deposit, current_user: User = Depends(get_current_
     credits = int(dep.amount * CREDIT_RATE)
     user["credits"] = user.get("credits", 0) + credits
     return {"credits": user["credits"]}
+
+
+@app.get("/subscriptions")
+async def get_subscriptions(current_user: User = Depends(get_current_user)):
+    """Return the user's active subscriptions."""
+    user = fake_users_db[current_user.username]
+    return {"subscriptions": user.get("services", [])}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,8 @@ import Dashboard from "./Dashboard";
 import UserPage from "./UserPage";
 import Wallet from "./Wallet";
 import Shop from "./Shop";
+import ContactUs from "./ContactUs";
+import Subscriptions from "./Subscriptions";
 
 export default function App() {
   return (
@@ -16,6 +18,8 @@ export default function App() {
         <Link to="/user">User</Link>
         <Link to="/wallet">Wallet</Link>
         <Link to="/shop">Shop</Link>
+        <Link to="/subscriptions">Subscriptions</Link>
+        <Link to="/contact">Contact Us</Link>
       </nav>
       <div className="p-4">
         <Routes>
@@ -24,6 +28,8 @@ export default function App() {
           <Route path="/user" element={<UserPage />} />
           <Route path="/wallet" element={<Wallet />} />
           <Route path="/shop" element={<Shop />} />
+          <Route path="/subscriptions" element={<Subscriptions />} />
+          <Route path="/contact" element={<ContactUs />} />
         </Routes>
       </div>
     </BrowserRouter>

--- a/frontend/src/ContactUs.tsx
+++ b/frontend/src/ContactUs.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export default function ContactUs() {
+  const mail = "namemine153+contactus@gmail.com";
+  const subject = encodeURIComponent("Contact Us Inquiry");
+  const body = encodeURIComponent("Please describe your issue here.");
+  const href = `mailto:${mail}?subject=${subject}&body=${body}`;
+
+  return (
+    <div className="max-w-sm mx-auto">
+      <h1 className="text-xl font-bold mb-4">Contact Us</h1>
+      <p>
+        You can reach us at{' '}
+        <a href={href} className="text-blue-500 underline">{mail}</a>.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/Subscriptions.tsx
+++ b/frontend/src/Subscriptions.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from "react";
+import { getSubscriptions } from "./api";
+
+export default function Subscriptions() {
+  const [subs, setSubs] = useState<{name: string; id: string; password: string;}[]>([]);
+
+  useEffect(() => {
+    getSubscriptions().then(data => setSubs(data.subscriptions)).catch(() => {});
+  }, []);
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Subscriptions</h1>
+      <ul className="space-y-2">
+        {subs.map(s => (
+          <li key={s.name} className="border p-2">
+            <div>{s.name}</div>
+            <div>ID: {s.id}</div>
+            <div>Password: {s.password}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -65,3 +65,11 @@ export async function deposit(amount: number) {
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
+
+export async function getSubscriptions() {
+  const res = await fetch(`${API_URL}/subscriptions`, {
+    headers: { ...authHeaders() }
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add `/subscriptions` endpoint to backend
- add contact and subscriptions pages
- wire up new routes and nav links
- support fetching subscriptions in API

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851120a71388333a9ac88d33051c52c