### PR TITLE
Add admin RBAC and notifications

### DIFF
--- a/frontend/src/Admin.tsx
+++ b/frontend/src/Admin.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import { adminAddSubscription, adminUpdateService } from "./api";
+
+export default function Admin() {
+  const [username, setUsername] = useState("");
+  const [service, setService] = useState("");
+  const [svcId, setSvcId] = useState("");
+  const [svcPass, setSvcPass] = useState("");
+  const [msg, setMsg] = useState("");
+
+  const addSub = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await adminAddSubscription(username, service);
+      setMsg("Subscription added");
+    } catch {
+      alert("Failed");
+    }
+  };
+
+  const updateSvc = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await adminUpdateService(service, svcId, svcPass);
+      setMsg("Service updated");
+    } catch {
+      alert("Failed");
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Admin</h1>
+      <form onSubmit={addSub} className="space-y-2">
+        <div>Add Subscription</div>
+        <input className="border p-2 w-full" placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <input className="border p-2 w-full" placeholder="Service" value={service} onChange={e => setService(e.target.value)} />
+        <button className="bg-blue-500 text-white py-1 px-3 rounded">Add</button>
+      </form>
+      <form onSubmit={updateSvc} className="space-y-2">
+        <div>Update Service Credentials</div>
+        <input className="border p-2 w-full" placeholder="Service" value={service} onChange={e => setService(e.target.value)} />
+        <input className="border p-2 w-full" placeholder="New ID" value={svcId} onChange={e => setSvcId(e.target.value)} />
+        <input className="border p-2 w-full" placeholder="New Password" value={svcPass} onChange={e => setSvcPass(e.target.value)} />
+        <button className="bg-blue-500 text-white py-1 px-3 rounded">Update</button>
+      </form>
+      {msg && <div>{msg}</div>}
+    </div>
+  );
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import Signup from "./Signup";
 import Login from "./Login";
@@ -8,8 +8,17 @@ import Wallet from "./Wallet";
 import Shop from "./Shop";
 import ContactUs from "./ContactUs";
 import Subscriptions from "./Subscriptions";
+import Admin from "./Admin";
+import Notifications from "./Notifications";
+import { getMe } from "./api";
 
 export default function App() {
+  const [role, setRole] = useState("");
+
+  useEffect(() => {
+    getMe().then(u => setRole(u.role)).catch(() => {});
+  }, []);
+
   return (
     <BrowserRouter>
       <nav className="p-4 space-x-2 bg-gray-100">
@@ -20,6 +29,8 @@ export default function App() {
         <Link to="/shop">Shop</Link>
         <Link to="/subscriptions">Subscriptions</Link>
         <Link to="/contact">Contact Us</Link>
+        <Link to="/notifications">Notifications</Link>
+        {role === "admin" && <Link to="/admin">Admin</Link>}
       </nav>
       <div className="p-4">
         <Routes>
@@ -30,6 +41,8 @@ export default function App() {
           <Route path="/shop" element={<Shop />} />
           <Route path="/subscriptions" element={<Subscriptions />} />
           <Route path="/contact" element={<ContactUs />} />
+          <Route path="/notifications" element={<Notifications />} />
+          <Route path="/admin" element={<Admin />} />
         </Routes>
       </div>
     </BrowserRouter>

--- a/frontend/src/ContactUs.tsx
+++ b/frontend/src/ContactUs.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 export default function ContactUs() {
+  const telegram = "https://t.me/percy_ecomm_chat";
   const mail = "namemine153+contactus@gmail.com";
   const subject = encodeURIComponent("Contact Us Inquiry");
   const body = encodeURIComponent("Please describe your issue here.");
@@ -10,7 +11,9 @@ export default function ContactUs() {
     <div className="max-w-sm mx-auto">
       <h1 className="text-xl font-bold mb-4">Contact Us</h1>
       <p>
-        You can reach us at{' '}
+        Join our Telegram group{' '}
+        <a href={telegram} className="text-blue-500 underline">here</a>
+        {' '}or email us at{' '}
         <a href={href} className="text-blue-500 underline">{mail}</a>.
       </p>
     </div>

--- a/frontend/src/Notifications.tsx
+++ b/frontend/src/Notifications.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from "react";
+import { getNotifications } from "./api";
+
+export default function Notifications() {
+  const [notes, setNotes] = useState<string[]>([]);
+
+  useEffect(() => {
+    getNotifications().then(n => setNotes(n.notifications)).catch(() => {});
+  }, []);
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Notifications</h1>
+      <ul className="space-y-2">
+        {notes.map((n, i) => (
+          <li key={i} className="border p-2">{n}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/Signup.tsx
+++ b/frontend/src/Signup.tsx
@@ -4,15 +4,23 @@ import { signup } from "./api";
 export default function Signup() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [userId, setUserId] = useState("");
   const [message, setMessage] = useState("");
+  const [suggestions, setSuggestions] = useState<string[]>([]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await signup(username, password);
+      await signup(username, password, userId);
       setMessage("User created, please login.");
-    } catch {
-      alert("Failed to sign up");
+      setSuggestions([]);
+    } catch (err: any) {
+      const msg = String(err.message || err);
+      if (msg.startsWith("user_id_exists")) {
+        setSuggestions(msg.split(":")[1].split(","));
+      } else {
+        alert("Failed to sign up");
+      }
     }
   };
 
@@ -21,10 +29,14 @@ export default function Signup() {
       <h1 className="text-xl font-bold mb-4">Signup</h1>
       <form onSubmit={handleSubmit} className="space-y-2">
         <input className="border p-2 w-full" placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <input className="border p-2 w-full" placeholder="User ID" value={userId} onChange={e => setUserId(e.target.value)} />
         <input className="border p-2 w-full" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
         <button className="bg-blue-500 text-white py-2 px-4 rounded">Signup</button>
       </form>
       {message && <p className="mt-4">{message}</p>}
+      {suggestions.length > 0 && (
+        <div className="mt-2">Suggested IDs: {suggestions.join(", ")}</div>
+      )}
     </div>
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,11 +5,11 @@ function authHeaders() {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-export async function signup(username: string, password: string) {
+export async function signup(username: string, password: string, userId: string) {
   const res = await fetch(`${API_URL}/signup`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ username, password }),
+    body: JSON.stringify({ username, password, user_id: userId }),
   });
   if (!res.ok) {
     throw new Error(await res.text());
@@ -69,6 +69,38 @@ export async function deposit(amount: number) {
 export async function getSubscriptions() {
   const res = await fetch(`${API_URL}/subscriptions`, {
     headers: { ...authHeaders() }
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function getMe() {
+  const res = await fetch(`${API_URL}/me`, { headers: { ...authHeaders() } });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function getNotifications() {
+  const res = await fetch(`${API_URL}/notifications`, { headers: { ...authHeaders() } });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function adminAddSubscription(username: string, service: string) {
+  const res = await fetch(`${API_URL}/admin/add-subscription`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ username, service_name: service })
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function adminUpdateService(service: string, id: string, password: string) {
+  const res = await fetch(`${API_URL}/admin/update-service`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ service_name: service, new_id: id, new_password: password })
   });
   if (!res.ok) throw new Error(await res.text());
   return res.json();


### PR DESCRIPTION
## Summary
- add RBAC-enabled admin user and service credentials storage
- add endpoints for notifications and admin service management
- allow user to select unique user ID at signup
- admin page and notification page in frontend
- add Telegram link for contact page

## Testing
- `npm run build` *(fails: vite not found)*
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6851131d6a288333bba1ec489509516b