### PR TITLE
Add error pages for 404 and access denied

### DIFF
--- a/frontend/src/AccessDenied.tsx
+++ b/frontend/src/AccessDenied.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export default function AccessDenied() {
+  return (
+    <div className="max-w-sm mx-auto">
+      <h1 className="text-xl font-bold mb-4">Access Denied</h1>
+      <p>You do not have permission to view this page.</p>
+      <p>
+        <Link to="/" className="text-blue-500 underline">Return home</Link>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,8 @@ import Subscriptions from "./Subscriptions";
 import Admin from "./Admin";
 import Notifications from "./Notifications";
 import { getMe } from "./api";
+import AccessDenied from "./AccessDenied";
+import NotFound from "./NotFound";
 
 export default function App() {
   const [role, setRole] = useState("");
@@ -43,6 +45,8 @@ export default function App() {
           <Route path="/contact" element={<ContactUs />} />
           <Route path="/notifications" element={<Notifications />} />
           <Route path="/admin" element={<Admin />} />
+          <Route path="/access-denied" element={<AccessDenied />} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </div>
     </BrowserRouter>

--- a/frontend/src/NotFound.tsx
+++ b/frontend/src/NotFound.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export default function NotFound() {
+  return (
+    <div className="max-w-sm mx-auto">
+      <h1 className="text-xl font-bold mb-4">404 - Page Not Found</h1>
+      <p>
+        The page you are looking for does not exist.{' '}
+        <Link to="/" className="text-blue-500 underline">Go home</Link>
+        .
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,16 +5,24 @@ function authHeaders() {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
+async function handle(res: Response) {
+  if (res.status === 401 || res.status === 403) {
+    window.location.href = "/access-denied";
+    throw new Error("access_denied");
+  }
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}
+
 export async function signup(username: string, password: string, userId: string) {
   const res = await fetch(`${API_URL}/signup`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ username, password, user_id: userId }),
   });
-  if (!res.ok) {
-    throw new Error(await res.text());
-  }
-  return res.json();
+  return handle(res);
 }
 
 export async function login(username: string, password: string) {
@@ -26,18 +34,14 @@ export async function login(username: string, password: string) {
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: data.toString(),
   });
-  if (!res.ok) {
-    throw new Error(await res.text());
-  }
-  return res.json();
+  return handle(res);
 }
 
 export async function getDashboard() {
   const res = await fetch(`${API_URL}/dashboard`, {
     headers: { ...authHeaders() }
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handle(res);
 }
 
 export async function changePassword(oldPass: string, newPass: string) {
@@ -46,14 +50,12 @@ export async function changePassword(oldPass: string, newPass: string) {
     headers: { "Content-Type": "application/json", ...authHeaders() },
     body: JSON.stringify({ old_password: oldPass, new_password: newPass })
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handle(res);
 }
 
 export async function getWallet() {
   const res = await fetch(`${API_URL}/wallet`, { headers: { ...authHeaders() } });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handle(res);
 }
 
 export async function deposit(amount: number) {
@@ -62,28 +64,24 @@ export async function deposit(amount: number) {
     headers: { "Content-Type": "application/json", ...authHeaders() },
     body: JSON.stringify({ amount })
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handle(res);
 }
 
 export async function getSubscriptions() {
   const res = await fetch(`${API_URL}/subscriptions`, {
     headers: { ...authHeaders() }
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handle(res);
 }
 
 export async function getMe() {
   const res = await fetch(`${API_URL}/me`, { headers: { ...authHeaders() } });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handle(res);
 }
 
 export async function getNotifications() {
   const res = await fetch(`${API_URL}/notifications`, { headers: { ...authHeaders() } });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handle(res);
 }
 
 export async function adminAddSubscription(username: string, service: string) {
@@ -92,8 +90,7 @@ export async function adminAddSubscription(username: string, service: string) {
     headers: { "Content-Type": "application/json", ...authHeaders() },
     body: JSON.stringify({ username, service_name: service })
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handle(res);
 }
 
 export async function adminUpdateService(service: string, id: string, password: string) {
@@ -102,6 +99,5 @@ export async function adminUpdateService(service: string, id: string, password: 
     headers: { "Content-Type": "application/json", ...authHeaders() },
     body: JSON.stringify({ service_name: service, new_id: id, new_password: password })
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  return handle(res);
 }


### PR DESCRIPTION
## Summary
- add NotFound and AccessDenied pages
- update routing to use them
- redirect to AccessDenied page when API returns 401/403

## Testing
- `npm run build` *(fails: Rollup failed to resolve react/jsx-runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68515483545483339d5493bdf860b0c9